### PR TITLE
Re-convert cooljeanius/LuaBitOp to GitHub Actions

### DIFF
--- a/.github/workflows/luabitop.yml
+++ b/.github/workflows/luabitop.yml
@@ -5,9 +5,6 @@ on:
     - "**/*"
     - master
   pull_request:
-concurrency:
-#   # This item has no matching transformer
-#   maximum_number_of_builds: 0
 jobs:
   test:
     runs-on: ubuntu-16.04

--- a/.github/workflows/luabitop.yml
+++ b/.github/workflows/luabitop.yml
@@ -5,12 +5,15 @@ on:
     - "**/*"
     - master
   pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.0.0
     - run: git clone git://github.com/LuaDist/Tools.git ~/_tools
     - run: "~/_tools/travis/travis install"
     - run: sudo apt-get install lua5.1 lua5.1-doc liblua5.1-0 liblua5.1-0-dbg liblua5.1-0-dev
@@ -22,9 +25,6 @@ jobs:
       if: "${{ success() }}"
     - run: test -e config.log && cat config.log
       if: "${{ failure() }}"
-#     # This item has no matching transformer
-#     - recipients:
-#       - luadist-dev@googlegroups.com
 #     # This item has no matching transformer
 #     - email:
 #         on_success: change


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/cooljeanius/LuaBitOp) :tada: (again)